### PR TITLE
Story 3.1 display error messages admin

### DIFF
--- a/api/src/Classes/Authenticate/Authenticate.php
+++ b/api/src/Classes/Authenticate/Authenticate.php
@@ -42,12 +42,18 @@ class Authenticate
         $requestString = explode(' ', $authHeader);
         //Grab the bearer token string from the array
         $bearerToken = $requestString[1];
+        $segments = explode('.', $bearerToken);
+        if (count($segments) !== 3) {
+            return $response->withJson(["success"=>false, "message"=>"Malformed token"]);
+        }
         try {
             $decoded = JWT::decode($bearerToken, $this->jwtKey, array('HS256'));
         } catch (\Firebase\JWT\ExpiredException $e) {
             return $response->withJson(["success"=>false, "message"=>"Token has expired"]);
         } catch (\Firebase\JWT\SignatureInvalidException $e) {
             return $response->withJson(["success"=>false, "message"=>"Invalid token"]);
+        } catch (Exception $e) {
+            return $response->withJson(["success"=>false, "message"=>"Token error"]);
         }
         return $next($request, $response);
 //        return $response;

--- a/api/src/Classes/Authenticate/Authenticate.php
+++ b/api/src/Classes/Authenticate/Authenticate.php
@@ -34,7 +34,7 @@ class Authenticate
     {
         //boot out if they dont have any Auth headers
         if(!$request->hasHeader('HTTP_AUTHORIZATION')){
-            return $response->withJson(["success"=>false]);
+            return $response->withJson(["success"=>false, "message"=>"No token received"]);
         }
         //Grab the value of the auth header
         $authHeader = $request->getHeader('HTTP_AUTHORIZATION')[0];

--- a/api/src/Classes/ErrorHandlers/ErrorHandler.php
+++ b/api/src/Classes/ErrorHandlers/ErrorHandler.php
@@ -5,9 +5,19 @@ use Slim\Http\Request as Request;
 use Slim\Http\Response as Response;
 use DomainException as Exception;
 
-
 class ErrorHandler
 {
+    /**
+     * A handler to send the error message on application errors as JSON.
+     *
+     * @param Request $request - the http request
+     *
+     * @param Response $response - the http response
+     *
+     * @param Exception $exception - the error thrown
+     *
+     * @return Response - the http response with JSON
+     */
     public function __invoke(Request $request, Response $response, Exception $exception)
     {
         $data['message']=$exception->getMessage();

--- a/api/src/Classes/ErrorHandlers/ErrorHandler.php
+++ b/api/src/Classes/ErrorHandlers/ErrorHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SignInApp\ErrorHandlers;
+use Slim\Http\Request as Request;
+use Slim\Http\Response as Response;
+use DomainException as Exception;
+
+
+class ErrorHandler
+{
+    public function __invoke(Request $request, Response $response, Exception $exception)
+    {
+        $data['message']=$exception->getMessage();
+
+        return $response
+            ->withStatus(500)
+            ->withJson($data);
+    }
+}

--- a/api/src/dependencies.php
+++ b/api/src/dependencies.php
@@ -28,6 +28,11 @@ return function (App $app) {
         return $db;
     };
 
+    //Error Handler
+    $container['errorHandler'] = function (Slim\Container $c) {
+        return new \SignInApp\ErrorHandlers\ErrorHandler();
+    };
+
     // JWT Key
     $container['jwtKey'] = function ($c) {
         return $c->get('settings')['jwtKey'];

--- a/api/src/dependencies.php
+++ b/api/src/dependencies.php
@@ -29,7 +29,7 @@ return function (App $app) {
     };
 
     //Error Handler
-    $container['errorHandler'] = function (Slim\Container $c) {
+    $container['errorHandler'] = function () {
         return new \SignInApp\ErrorHandlers\ErrorHandler();
     };
 

--- a/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
+++ b/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
@@ -10,14 +10,7 @@ class AdminContainer extends React.Component {
     };
 
     updateResponse = (newResponse) => {
-        setTimeout(()=> {
-            this.clearResponse()
-        }, 3000);
         this.setState({response : newResponse})
-    };
-
-    clearResponse = () => {
-        this.setState({response : ''})
     };
 
     render() {

--- a/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
+++ b/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
@@ -2,14 +2,31 @@ import React from "react";
 import './adminContainer.css';
 import Logo from '../../LandingPage/MainContainer/Logo/Logo';
 import VisitorsTable from "../VisitorsTable/VisitorsTable";
+import MessageBox from "../../LandingPage/MainContainer/MessageBox/MessageBox"
 
 class AdminContainer extends React.Component {
+    state = {
+        response: ''
+    };
+
+    updateResponse = (newResponse) => {
+        setTimeout(()=> {
+            this.clearResponse()
+        }, 3000);
+        this.setState({response : newResponse})
+    };
+
+    clearResponse = () => {
+        this.setState({response : ''})
+    };
+
     render() {
         return (
             <main>
                 <div className="adminContainer">
                     <Logo/>
-                    <VisitorsTable/>
+                    <VisitorsTable updateResponse={this.updateResponse}/>
+                    <MessageBox response={this.state.response}/>
                 </div>
             </main>
         )

--- a/app/src/Components/AdminPage/AdminPage.js
+++ b/app/src/Components/AdminPage/AdminPage.js
@@ -19,34 +19,12 @@ class AdminPage extends React.Component{
         if (localStorage.getItem('bearerToken') === null) {
             return window.location.replace(this.state.appUrl)
         }
-        // this.fetchVisitors();
 
         setTimeout(() => {
 
             window.location.replace(this.state.appUrl)
         }, 300000)
     }
-
-
-
-    // fetchVisitors = () => {
-    //     fetch(this.state.apiUrl + 'api/admin', {
-    //         method: 'GET',
-    //         headers: {
-    //             "Content-Type" : "application/json",
-    //             "Authorization" : "Bearer " + this.state.bearerToken
-    //         }
-    //     })
-    //         .then(data=>data.json())
-    //         .then((data)=>{
-    //             this.setState({
-    //                 success: data.Success
-    //             });
-    //             if (!(this.state.success)) {
-    //                 window.location.replace(this.state.appUrl)
-    //             }
-    //         })
-    // };
 
     render() {
         return (

--- a/app/src/Components/AdminPage/AdminPage.js
+++ b/app/src/Components/AdminPage/AdminPage.js
@@ -19,7 +19,7 @@ class AdminPage extends React.Component{
         if (localStorage.getItem('bearerToken') === null) {
             return window.location.replace(this.state.appUrl)
         }
-        this.fetchVisitors();
+        // this.fetchVisitors();
 
         setTimeout(() => {
             localStorage.removeItem('bearerToken');
@@ -27,24 +27,24 @@ class AdminPage extends React.Component{
         }, 300000)
     }
 
-    fetchVisitors = () => {
-        fetch(this.state.apiUrl + 'api/admin', {
-            method: 'GET',
-            headers: {
-                "Content-Type" : "application/json",
-                "Authorization" : "Bearer " + this.state.bearerToken
-            }
-        })
-            .then(data=>data.json())
-            .then((data)=>{
-                this.setState({
-                    success: data.Success
-                });
-                if (!(this.state.success)) {
-                    window.location.replace(this.state.appUrl)
-                }
-            })
-    };
+    // fetchVisitors = () => {
+    //     fetch(this.state.apiUrl + 'api/admin', {
+    //         method: 'GET',
+    //         headers: {
+    //             "Content-Type" : "application/json",
+    //             "Authorization" : "Bearer " + this.state.bearerToken
+    //         }
+    //     })
+    //         .then(data=>data.json())
+    //         .then((data)=>{
+    //             this.setState({
+    //                 success: data.Success
+    //             });
+    //             if (!(this.state.success)) {
+    //                 window.location.replace(this.state.appUrl)
+    //             }
+    //         })
+    // };
 
     render() {
         return (

--- a/app/src/Components/AdminPage/AdminPage.js
+++ b/app/src/Components/AdminPage/AdminPage.js
@@ -22,10 +22,12 @@ class AdminPage extends React.Component{
         // this.fetchVisitors();
 
         setTimeout(() => {
-            localStorage.removeItem('bearerToken');
+
             window.location.replace(this.state.appUrl)
         }, 300000)
     }
+
+
 
     // fetchVisitors = () => {
     //     fetch(this.state.apiUrl + 'api/admin', {

--- a/app/src/Components/AdminPage/LogOutBtn/LogOutBtn.js
+++ b/app/src/Components/AdminPage/LogOutBtn/LogOutBtn.js
@@ -3,7 +3,9 @@ import './logOutBtn.css';
 
 class LogOutBtn extends React.Component {
     handleClick = () => {
-        localStorage.removeItem('bearerToken');
+        if (!localStorage.getItem('bearerToken')) {
+            localStorage.removeItem('bearerToken');
+        }
         window.location.replace(localStorage.getItem('appUrl'))
     };
 

--- a/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
+++ b/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
@@ -10,7 +10,8 @@ class VisitorsTable extends React.Component {
             visitorPackage: {
                 "Data": []
             },
-            bearerToken: localStorage.getItem('bearerToken')
+            bearerToken: localStorage.getItem('bearerToken'),
+            appUrl: localStorage.getItem('appUrl')
         };
     }
 
@@ -29,6 +30,12 @@ class VisitorsTable extends React.Component {
         })
         .then(data=>data.json())
         .then((data)=>{
+            if (data.message === null || data.message ==='Invalid token' || data.message === 'Malformed token' ||
+            data.message === 'Token has expired' || data.message === 'Token error' ||
+                data.message === 'No token received') {
+                localStorage.removeItem('bearerToken');
+                window.location.replace(this.state.appUrl)
+            }
             this.setState({
                 visitorPackage: data
             })

--- a/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
+++ b/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
@@ -20,7 +20,7 @@ class VisitorsTable extends React.Component {
     }
 
     fetchVisitors = () => {
-        const url = localStorage.getItem('apiUrl') + '/api/admin';
+        const url = localStorage.getItem('apiUrl') + 'api/admin';
         fetch(url, {
             method: 'GET',
             headers: {

--- a/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
+++ b/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
@@ -35,6 +35,7 @@ class VisitorsTable extends React.Component {
             if (!data.Data.length > 0) {
                 this.props.updateResponse(data.Message);
             }
+            localStorage.removeItem('bearerToken')
         })
     };
 

--- a/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
+++ b/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
@@ -32,7 +32,9 @@ class VisitorsTable extends React.Component {
             this.setState({
                 visitorPackage: data
             })
-            this.props.updateResponse('Hello this is a success message');
+            if (!data.Data.length > 0) {
+                this.props.updateResponse(data.Message);
+            }
         })
     };
 

--- a/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
+++ b/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
@@ -12,8 +12,6 @@ class VisitorsTable extends React.Component {
             },
             bearerToken: localStorage.getItem('bearerToken')
         };
-
-        console.log(this.state.bearerToken)
     }
 
     componentDidMount() {
@@ -34,6 +32,7 @@ class VisitorsTable extends React.Component {
             this.setState({
                 visitorPackage: data
             })
+            this.props.updateResponse('Hello this is a success message');
         })
     };
 

--- a/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
+++ b/app/src/Components/AdminPage/VisitorsTable/VisitorsTable.js
@@ -30,9 +30,9 @@ class VisitorsTable extends React.Component {
         })
         .then(data=>data.json())
         .then((data)=>{
-            if (data.message === null || data.message ==='Invalid token' || data.message === 'Malformed token' ||
-            data.message === 'Token has expired' || data.message === 'Token error' ||
-                data.message === 'No token received') {
+            if (data.message === null || data.message ==='Invalid token' ||
+                data.message === 'Malformed token' || data.message === 'Token has expired' ||
+                data.message === 'Token error' || data.message === 'No token received') {
                 localStorage.removeItem('bearerToken');
                 window.location.replace(this.state.appUrl)
             }

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -19,7 +19,8 @@ class AdminModal extends React.Component {
     }
 
     updateToken = (fetchedToken) => {
-        let updatedToken = fetchedToken;
+        // let updatedToken = fetchedToken;
+        let updatedToken = ''; //use this for testing, uncomment above line in live, and comment out this one.
         this.setState({bearerToken: updatedToken});
         localStorage.setItem('bearerToken', updatedToken)
     };

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -20,7 +20,6 @@ class AdminModal extends React.Component {
 
     updateToken = (fetchedToken) => {
         let updatedToken = fetchedToken;
-        // let updatedToken = 'jsklfjajsdlkfjla'; //use this for testing, uncomment above line in live, and comment out this one.
         this.setState({bearerToken: updatedToken});
         localStorage.setItem('bearerToken', updatedToken)
     };

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -19,8 +19,8 @@ class AdminModal extends React.Component {
     }
 
     updateToken = (fetchedToken) => {
-        // let updatedToken = fetchedToken;
-        let updatedToken = ''; //use this for testing, uncomment above line in live, and comment out this one.
+        let updatedToken = fetchedToken;
+        // let updatedToken = 'jsklfjajsdlkfjla'; //use this for testing, uncomment above line in live, and comment out this one.
         this.setState({bearerToken: updatedToken});
         localStorage.setItem('bearerToken', updatedToken)
     };

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -38,7 +38,7 @@ class Routing extends React.Component {
                 <div>
                     <Switch>
                         <Route exact path="/" component={ LandingPage }/>
-                        <Route path="/adminPage" component={ AdminPage }/>
+                        <Route onLeave= { () => localStorage.removeItem('bearerToken') } path="/adminPage" component={ AdminPage }/>
                         <Route component={ LandingPage }/>
                     </Switch>
                 </div>

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -31,14 +31,13 @@ class Routing extends React.Component {
         }
     }
 
-
     render() {
         return (
             <Router>
                 <div>
                     <Switch>
                         <Route exact path="/" component={ LandingPage }/>
-                        <Route onLeave= { () => localStorage.removeItem('bearerToken') } path="/adminPage" component={ AdminPage }/>
+                        <Route path="/adminPage" component={ AdminPage }/>
                         <Route component={ LandingPage }/>
                     </Switch>
                 </div>


### PR DESCRIPTION
Added:
On admin page, if there are no results to display, you see an error message.
In the background, added handling of token errors so that you are returned to the landing page if you are submitting an invalid token.

To test
1. use postman:
Send requests to http://localhost:8080/api/admin with a random string with two dots like
asdlfjaklsdfj.klajsfdljaslkdfj.aldsjflkasjfdl
You should receive the message "Syntax error, malformed JSON"

2. In the app, in Admin Modal, comment out line 22, then comment line 23 back in.  Make updatedToken equal to:
'' (a blank string), upon logging in, you should be returned to the landing page
'kalsdjhdfkjhajkfhk' (a string of random characters), upon logging in, you should be returned to the landing page
'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1ODgyNTczODQsImlhdCI6MTU4ODI1NzMyNH0.dK-4El0AMa9cOP4xwAw3Bc13e6IBEW2WsQC0lqda2vA' (an expired token), you should be returned to the login page.

Then comment out line 23, and comment line 22 back in. On logging in, you should see the admin page, either with a message if you have no signed in visitors, or the table of visitors.
