### PR TITLE
Admin Button Bug

### DIFF
--- a/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
+++ b/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
@@ -18,7 +18,10 @@ class AdminBtn extends React.Component {
 
     handleClick = () => {
         this.props.updateModalVisible();
-        this.props.updateSignOutModalVisible();
+
+        if (this.props.signOutModalVisible) {
+            this.props.updateSignOutModalVisible();
+        }
     };
 
     render() {

--- a/app/src/Components/LandingPage/LandingPage.js
+++ b/app/src/Components/LandingPage/LandingPage.js
@@ -59,6 +59,7 @@ class LandingPage extends React.Component {
                 <AdminBtn
                     adminBtnVisible={this.state.adminBtnVisible}
                     updateModalVisible={this.updateModalVisible}
+                    signOutModalVisible={this.state.signOutModalVisible}
                     updateSignOutModalVisible={this.updateSignOutModalVisible}
                 />
             </div>


### PR DESCRIPTION
After initially fixing the bug where clicking the admin button whilst the visitorSignOutModal is visible meant the keypad appeared underneath was done, another bug appeared where just clicking the admin button on the landing page made both modals appear, one on top of the other. This branch fixes that new bug.