### PR TITLE
S5 t3 auto sign out past visitors

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -89,15 +89,15 @@ To test, passcode is 8974.
 - Sends: 
     - `{ "Name": "string", "Company": "string" }`
     
-    - Returns:
-        - if successful 
-            - `status 200`
-            - `{ "Success": true, "Message": "Visitor successfully signed out", "Data": [] }`  
-        - if unsuccessful
-            - `status 422` 
-                - `{ "Success": false, "Message": "Multiple matches found", "Data": [all matches on same name and their time of sign out] }`
-            - `status 500` 
-                - `{ "Success": false, "Message": "Unable to connect to server", "Data": [] }`
+- Returns:
+    - if successful 
+        - `status 200`
+        - `{ "Success": true, "Message": "Visitor successfully signed out", "Data": [] }`  
+    - if unsuccessful
+        - `status 422` 
+            - `{ "Success": false, "Message": "Multiple matches found", "Data": [all matches on same name and their time of sign out] }`
+        - `status 500` 
+            - `{ "Success": false, "Message": "Unable to connect to server", "Data": [] }`
     
     OR
 
@@ -165,5 +165,28 @@ To test, passcode is 8974.
     - if unsuccessful
         - `status 400` 
             - `{ "Success": false, "Message": "No data retrieved or no data in database", "Data": [] }`
+        - `status 500` 
+            - `{ "Success": false, "Message": "Unable to connect to server", "Data": [] }`
+            
+
+### PUT
+**/api/signOutVisitors**
+
+You must be authenticated to retrieve data from this route.
+To test, passcode is 8974.
+
+- Sets all visitors to signed out where signed in is true and date of visit is before current date
+- Logs time visitors signed out in the DB
+
+- Required and sends
+    - `{ "Option" : "all-previous" }` - Option with all-previous set
+
+- Returns:
+    - if successful 
+        - `status 200`
+        - `{ "Success": true, "Message": "Successfully updated visitors", "Data": [] }`  
+    - if unsuccessful
+        - `status 400` 
+            - `{ "Success": false, "Message": "Key must be 'Option', must be set and set to 'all-previous'", "Data": [] }`
         - `status 500` 
             - `{ "Success": false, "Message": "Unable to connect to server", "Data": [] }`

--- a/api/src/Classes/Controllers/SignOutVisitorController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorController.php
@@ -13,7 +13,7 @@ class SignOutVisitorController extends ValidationEntity
     private $visitorModel;
 
     /** Constructor assigns VisitorModel to this object
-     *  AddVisitorController constructor.
+     *  SignOutVisitorController constructor.
      *
      * @param VisitorModel $visitorModel
      */

--- a/api/src/Classes/Controllers/SignOutVisitorController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorController.php
@@ -12,7 +12,8 @@ class SignOutVisitorController extends ValidationEntity
 {
     private $visitorModel;
 
-    /** Constructor assigns VisitorModel to this object
+    /**
+     *  Constructor assigns VisitorModel to this object
      *  SignOutVisitorController constructor.
      *
      * @param VisitorModel $visitorModel
@@ -23,8 +24,9 @@ class SignOutVisitorController extends ValidationEntity
     }
 
     /**
-     *On invoke check input for Name or ID value, if data there, call appropriate methods from VisitorModel
+     * On invoke check input for Name or ID value, if data there, call appropriate methods from VisitorModel
      * (signOutById or signOutByName) and respond as whether that was successful or not
+     *
      * @param Request $request
      * @param Response $response
      * @param array $args

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -11,7 +11,8 @@ class SignOutVisitorsController
 {
     private $visitorModel;
 
-    /** Constructor assigns VisitorModel to this object
+    /**
+     *  Constructor assigns VisitorModel to this object
      *  SignOutVisitorsController constructor.
      *
      * @param VisitorModel $visitorModel
@@ -21,6 +22,15 @@ class SignOutVisitorsController
         $this->visitorModel = $visitorModel;
     }
 
+    /**
+     *  On invoke checks option set in request and updates signed out where signed in is 1 and date of visit
+     *  is not the current date
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param array $args
+     * @return Response
+     */
     public function __invoke(Request $request, Response $response, array $args)
     {
         $requestData = $request->getParsedBody();

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SignInApp\Controllers;
+
+use SignInApp\Models\VisitorModel;
+use SignInApp\Entities\ValidationEntity;
+use \DateTime;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+class SignOutVisitorsController extends ValidationEntity
+{
+    private $visitorModel;
+
+    /** Constructor assigns VisitorModel to this object
+     *  SignOutVisitorsController constructor.
+     *
+     * @param VisitorModel $visitorModel
+     */
+    public function __construct(VisitorModel $visitorModel)
+    {
+        $this->visitorModel = $visitorModel;
+    }
+
+    public function __invoke(Request $request, Response $response, array $args)
+    {
+        // TODO: Implement __invoke() method.
+    }
+}

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -25,6 +25,8 @@ class SignOutVisitorsController
     {
         $requestData = $request->getParsedBody();
         $option = $requestData['Option'];
+        $now = new DateTime('Europe/London');
+        $timeOfSignOut = $now->format('H:i:s');
 
         $apiResponse = [
             'Success' => false,
@@ -35,8 +37,17 @@ class SignOutVisitorsController
 
         if (!(isset($option)) || $option !== 'all-previous') {
             $statusCode = 400;
-            $apiResponse['Message'] = 'Option must be set and set to \'all-previous\'';
+            $apiResponse['Message'] = 'Key must be \'Option\', must be set and set to \'all-previous\'';
             return $response->withJson($apiResponse, $statusCode);
+        }
+
+        if ($option === 'all-previous') {
+            $updatedVisitors = $this->visitorModel->signOutAllVisitorsUpToToday($timeOfSignOut);
+            if ($updatedVisitors === true) {
+                $statusCode = 200;
+                $apiResponse['Message'] = 'Successfully updated visitors';
+                return $response->withJson($apiResponse, $statusCode);
+            }
         }
 
         return $response->withJson($apiResponse, $statusCode);

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -3,12 +3,11 @@
 namespace SignInApp\Controllers;
 
 use SignInApp\Models\VisitorModel;
-use SignInApp\Entities\ValidationEntity;
 use \DateTime;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class SignOutVisitorsController extends ValidationEntity
+class SignOutVisitorsController
 {
     private $visitorModel;
 
@@ -24,6 +23,22 @@ class SignOutVisitorsController extends ValidationEntity
 
     public function __invoke(Request $request, Response $response, array $args)
     {
-        // TODO: Implement __invoke() method.
+        $requestData = $request->getParsedBody();
+        $option = $requestData['Option'];
+
+        $apiResponse = [
+            'Success' => false,
+            'Message' => 'Unable to connect to server',
+            'Data' => []
+        ];
+        $statusCode = 500;
+
+        if (!(isset($option)) || $option !== 'all-previous') {
+            $statusCode = 400;
+            $apiResponse['Message'] = 'Option must be set and set to \'all-previous\'';
+            return $response->withJson($apiResponse, $statusCode);
+        }
+
+        return $response->withJson($apiResponse, $statusCode);
     }
 }

--- a/api/src/Classes/Factories/SignOutVisitorsControllerFactory.php
+++ b/api/src/Classes/Factories/SignOutVisitorsControllerFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SignInApp\Factories;
+
+use Psr\Container\ContainerInterface;
+use SignInApp\Controllers\SignOutVisitorsController;
+
+class SignOutVisitorsControllerFactory
+{
+    /**
+     * Instantiates a new SignOutVisitorsController with a VisitorModel injected as a dependency
+     *
+     * @param ContainerInterface $container
+     * @return SignOutVisitorsController
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        $visitorModel = $container->get('VisitorModel');
+        return new SignOutVisitorsController($visitorModel);
+    }
+}

--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -156,4 +156,22 @@ class VisitorModel
         $query->bindParam(':timeOfSignOut', $timeOfSignOut);
         return $query->execute();
     }
+
+    /**
+     * signs out all visitors who are currently signed in but DateOfVisit is not current days date
+     *
+     * @param $timeOfSignOut
+     * @return bool
+     */
+    public function signOutAllVisitorsUpToToday($timeOfSignOut) : bool
+    {
+        $query = $this->db->prepare(
+            'UPDATE `visitors` 
+            SET `SignedIn` = 0, `TimeOfSignOut` = :timeOfSignOut
+            WHERE `SignedIn` = 1
+            AND `DateOfVisit` < CURDATE();'
+        );
+        $query->bindParam(':timeOfSignOut', $timeOfSignOut);
+        return $query->execute();
+    }
 }

--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -66,7 +66,7 @@ class VisitorModel
             FROM `visitors`
             WHERE `SignedIn` = 0
             AND `id` < :id
-            ORDER BY `DateOfVisit` DESC, `TimeOfSignOut` DESC
+            ORDER BY `id` DESC
             LIMIT :count;'
         );
         $query->bindParam(':id', $start, \PDO::PARAM_INT);

--- a/api/src/dependencies.php
+++ b/api/src/dependencies.php
@@ -49,6 +49,7 @@ return function (App $app) {
     $container['SignOutVisitorController'] = new \SignInApp\Factories\SignOutVisitorControllerFactory();
     $container['GetAllSignedOutVisitorsController'] = new SignInApp\Factories\GetAllSignedOutVisitorsControllerFactory();
     $container['GetBatchOfSignedOutVisitorsController'] = new SignInApp\Factories\GetBatchOfSignedOutVisitorsControllerFactory();
+    $container['SignOutVisitorsController'] = new SignInApp\Factories\SignOutVisitorsControllerFactory();
 
     //Authentication
     $container['Authenticate'] = new SignInApp\Factories\AuthenticateFactory();

--- a/api/src/routes.php
+++ b/api/src/routes.php
@@ -38,7 +38,7 @@ return function (App $app) {
     //Api Routes
     $app->post('/api/visitorSignIn', 'AddVisitorController');
     $app->put('/api/visitorSignOut', 'SignOutVisitorController');
-    $app->put('/api/signOutVisitors','SignOutVisitorsController');
+    $app->put('/api/signOutVisitors','SignOutVisitorsController')->add('Authenticate');
     $app->get('/api/admin', 'GetAllSignedInVisitorsController')->add('Authenticate');
     $app->get('/api/signedOutVisitors', 'GetAllSignedOutVisitorsController')->add('Authenticate');
     $app->get('/api/signedOutVisitorsByBatch', 'GetBatchOfSignedOutVisitorsController')->add('Authenticate');

--- a/api/src/routes.php
+++ b/api/src/routes.php
@@ -38,7 +38,7 @@ return function (App $app) {
     //Api Routes
     $app->post('/api/visitorSignIn', 'AddVisitorController');
     $app->put('/api/visitorSignOut', 'SignOutVisitorController');
-    $app->put('api/signOutVisitors','SignOutVisitorsController');
+    $app->put('/api/signOutVisitors','SignOutVisitorsController');
     $app->get('/api/admin', 'GetAllSignedInVisitorsController')->add('Authenticate');
     $app->get('/api/signedOutVisitors', 'GetAllSignedOutVisitorsController')->add('Authenticate');
     $app->get('/api/signedOutVisitorsByBatch', 'GetBatchOfSignedOutVisitorsController')->add('Authenticate');

--- a/api/src/routes.php
+++ b/api/src/routes.php
@@ -37,8 +37,9 @@ return function (App $app) {
 
     //Api Routes
     $app->post('/api/visitorSignIn', 'AddVisitorController');
-    $app->get('/api/admin', 'GetAllSignedInVisitorsController')->add('Authenticate');
     $app->put('/api/visitorSignOut', 'SignOutVisitorController');
+    $app->put('api/signOutVisitors','SignOutVisitorsController');
+    $app->get('/api/admin', 'GetAllSignedInVisitorsController')->add('Authenticate');
     $app->get('/api/signedOutVisitors', 'GetAllSignedOutVisitorsController')->add('Authenticate');
     $app->get('/api/signedOutVisitorsByBatch', 'GetBatchOfSignedOutVisitorsController')->add('Authenticate');
 

--- a/api/tests/Controllers/SignOutVisitorsControllerTest.php
+++ b/api/tests/Controllers/SignOutVisitorsControllerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Controllers;
+
+use PHPUnit\Framework\TestCase;
+use SignInApp\Models\VisitorModel;
+use SignInApp\Controllers\SignOutVisitorsController;
+
+class SignOutVisitorsControllerTest extends TestCase
+{
+    /**
+     *  makes sure controller is instantiated with access to VisitorModel
+     */
+    public function testSuccessConstruct()
+    {
+        $visitorModel = $this->createMock(VisitorModel::class);
+        $case = new SignOutVisitorsController($visitorModel);
+        $expected = SignOutVisitorsController::class;
+        $this->assertInstanceOf($expected, $case);
+    }
+}

--- a/api/tests/Factories/SignOutVisitorsControllerFactoryTest.php
+++ b/api/tests/Factories/SignOutVisitorsControllerFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Test\Factories;
+
+use PHPUnit\Framework\TestCase;
+use SignInApp\Factories\SignOutVisitorsControllerFactory;
+use SignInApp\Controllers\SignOutVisitorsController;
+use SignInApp\Models\VisitorModel;
+use Psr\Container\ContainerInterface;
+
+class SignOutVisitorsControllerFactoryTest extends TestCase
+{
+    /**
+     * checks to make sure factory class instantiated when calling new factory
+     */
+    public function testInstantiation()
+    {
+        $factory = new SignOutVisitorsControllerFactory();
+        $expected = SignOutVisitorsControllerFactory::class;
+        $this->assertInstanceOf($expected, $factory);
+    }
+
+    /**
+     * Tests the invoke magic method, asserting that a SignOutVisitorController object is instantiated.
+     */
+    public function testInvoke()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $visitorModel = $this->createMock(VisitorModel::class);
+        $container->method('get')->willReturn($visitorModel);
+
+        $factory = new SignOutVisitorsControllerFactory();
+        $case = $factory($container);
+        $expected = SignOutVisitorsController::class;
+        $this->assertInstanceOf($expected, $case);
+    }
+}

--- a/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
+++ b/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
@@ -9,12 +9,30 @@ import VisitorsTableSignedOut from "../VisitorsTableSignedOut/VisitorsTableSigne
 
 class AdminContainer extends React.Component {
     state = {
+        bearerToken: localStorage.getItem('bearerToken'),
         response: '',
         adminContainerVisible: 'hidden',
         signedInTableVisible: true,
         signedOutTableVisible: false,
         visitorSignedOut: {}
     };
+
+    componentDidMount() {
+        this.updateSignedOutDb()
+    }
+
+    updateSignedOutDb = async () => {
+        const url = localStorage.getItem('apiUrl') + 'api/signOutVisitors';
+        const option = JSON.stringify({ "Option" : "all-previous" })
+        const updatedVisitors = await fetch(url, {
+            method: "PUT",
+            body: option,
+            headers: {
+                "Content-Type" : "application/json",
+                "Authorization" : "Bearer " + this.state.bearerToken
+            }
+        })
+    }
 
     setAdminContainerVisible = () => {
         this.setState({adminContainerVisible: 'visible'})

--- a/app/src/Components/AdminPage/VisitorsTableSignedIn/visitorsTable.css
+++ b/app/src/Components/AdminPage/VisitorsTableSignedIn/visitorsTable.css
@@ -12,3 +12,22 @@
 .endMessage {
     font-weight: 300;
 }
+
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+    border-top: 1px solid #DDDDDD;
+    border-right: 1px solid #DDDDDD;
+}
+
+.visitorSignedOutTable {
+    border-left: 1px solid #DDDDDD;
+    border-bottom: 1px solid #DDDDDD;
+}
+
+.vSignedOutTable .table thead th {
+    border-bottom: 1px solid #DDDDDD;
+}

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -22,14 +22,15 @@ class VisitorsTableSignedOut extends React.Component {
     }
 
     initialTableRenderData = async () => {
-        let firstBatch = await this.fetchVisitors(15, 999999);
+        const count = 15;
+        let firstBatch = await this.fetchVisitors(count, 999999);
         let orderedPackage = this.reorderVisitorPackage(firstBatch)
         await this.setState({
             visitorPackage: orderedPackage,
             lastFetchedVisitors: orderedPackage
         })
 
-        if (firstBatch.length < 15) {
+        if (firstBatch.length < count) {
             this.setState({
                 endMessageVisibility: 'd-none',
                 hasMore: false

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -8,6 +8,7 @@ class VisitorsTableSignedOut extends React.Component {
 
         this.state = {
             visitorPackage: [],
+            lastFetchedVisitors: [],
             bearerToken: localStorage.getItem('bearerToken'),
             appUrl: localStorage.getItem('appUrl'),
             signedOutTableVisible: 'd-none',
@@ -21,7 +22,10 @@ class VisitorsTableSignedOut extends React.Component {
 
     initialTableRenderData = async () => {
         let firstBatch = await this.fetchVisitors(15, 999999);
-        this.setState({visitorPackage: firstBatch})
+        this.setState({
+            visitorPackage: firstBatch,
+            lastFetchedVisitors: firstBatch
+        })
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -104,24 +108,31 @@ class VisitorsTableSignedOut extends React.Component {
         return dayMonthYear.join('/');
     };
 
+    //take original order and re-order descending by date and time of sign out
+    reorderVisitorPackage = (originalOrder) => {
+
+    }
+
     updateTable = async () => {
         const count = 15;
-        const start = this.state.visitorPackage.slice(-1)[0].id;
+        const start = this.state.lastFetchedVisitors.slice(-1)[0].id;
 
         if (start < 2) {
             this.setState({hasMore: false})
         }
 
-        let fetchNextBatch = await this.fetchVisitors(count, start)
-        this.updateVisitorPackage(fetchNextBatch)
+        let fetchedNextBatch = await this.fetchVisitors(count, start)
+        this.updateVisitorPackage(fetchedNextBatch)
 
         console.log(this.state.visitorPackage)
+        console.log(start)
     }
 
     updateVisitorPackage = (data) => {
         setTimeout(() => {
             this.setState({
-                visitorPackage: this.state.visitorPackage.concat(data)
+                visitorPackage: this.state.visitorPackage.concat(data),
+                lastFetchedVisitors: data
             })
         }, 750)
     }

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -12,6 +12,7 @@ class VisitorsTableSignedOut extends React.Component {
             bearerToken: localStorage.getItem('bearerToken'),
             appUrl: localStorage.getItem('appUrl'),
             signedOutTableVisible: 'd-none',
+            endMessageVisibility: 'd-block',
             hasMore: true
         };
     }
@@ -23,10 +24,17 @@ class VisitorsTableSignedOut extends React.Component {
     initialTableRenderData = async () => {
         let firstBatch = await this.fetchVisitors(15, 999999);
         let orderedPackage = this.reorderVisitorPackage(firstBatch)
-        this.setState({
+        await this.setState({
             visitorPackage: orderedPackage,
             lastFetchedVisitors: orderedPackage
         })
+
+        if (firstBatch.length < 15) {
+            this.setState({
+                endMessageVisibility: 'd-none',
+                hasMore: false
+            })
+        }
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -128,7 +136,8 @@ class VisitorsTableSignedOut extends React.Component {
 
         let fetchedNextBatch = await this.fetchVisitors(count, start)
         this.updateVisitorPackage(fetchedNextBatch)
-
+        console.log(this.state.visitorPackage)
+        console.log(start)
     }
 
     updateVisitorPackage = (data) => {
@@ -143,6 +152,7 @@ class VisitorsTableSignedOut extends React.Component {
 
     render() {
         const signedOutTableClass = 'col-12 visitorsTable ' + this.state.signedOutTableVisible;
+        const endMessageClass = 'endMessage ' + this.state.endMessageVisibility;
         return (
             <div className={signedOutTableClass}>
                 <InfiniteScroll
@@ -151,7 +161,7 @@ class VisitorsTableSignedOut extends React.Component {
                     hasMore={this.state.hasMore}
                     loader={<h5>loading...</h5>}
                     endMessage={
-                        <h5 className="endMessage">
+                        <h5 className={endMessageClass}>
                             <b>You have reached the end, no more signed out visitors logged.</b>
                         </h5>
                     }

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -152,7 +152,7 @@ class VisitorsTableSignedOut extends React.Component {
     }
 
     render() {
-        const signedOutTableClass = 'col-12 visitorsTable ' + this.state.signedOutTableVisible;
+        const signedOutTableClass = 'col-12 visitorsTable vSignedOutTable ' + this.state.signedOutTableVisible;
         const endMessageClass = 'endMessage ' + this.state.endMessageVisibility;
         return (
             <div className={signedOutTableClass}>
@@ -167,7 +167,7 @@ class VisitorsTableSignedOut extends React.Component {
                         </h5>
                     }
                 >
-                    <table className="table table-bordered table-hover">
+                    <table className="table visitorSignedOutTable table-hover">
                         <thead>
                         <tr className="d-flex">
                             <th key="Name" className="col-3">Name</th>

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -22,9 +22,10 @@ class VisitorsTableSignedOut extends React.Component {
 
     initialTableRenderData = async () => {
         let firstBatch = await this.fetchVisitors(15, 999999);
+        let orderedPackage = this.reorderVisitorPackage(firstBatch)
         this.setState({
-            visitorPackage: firstBatch,
-            lastFetchedVisitors: firstBatch
+            visitorPackage: orderedPackage,
+            lastFetchedVisitors: orderedPackage
         })
     }
 
@@ -108,9 +109,13 @@ class VisitorsTableSignedOut extends React.Component {
         return dayMonthYear.join('/');
     };
 
-    //take original order and re-order descending by date and time of sign out
     reorderVisitorPackage = (originalOrder) => {
-
+        return originalOrder.sort((visitor_1, visitor_2) => {
+            if (new Date(visitor_1.DateOfVisit) > new Date(visitor_2.DateOfVisit)) return -1;
+            if (new Date(visitor_1.DateOfVisit) < new Date(visitor_2.DateOfVisit)) return 1;
+            if (visitor_1.TimeOfSignOut > visitor_2.TimeOfSignOut) return -1;
+            if (visitor_1.TimeOfSignOut < visitor_2.TimeOfSignOut) return 1;
+        })
     }
 
     updateTable = async () => {
@@ -124,14 +129,13 @@ class VisitorsTableSignedOut extends React.Component {
         let fetchedNextBatch = await this.fetchVisitors(count, start)
         this.updateVisitorPackage(fetchedNextBatch)
 
-        console.log(this.state.visitorPackage)
-        console.log(start)
     }
 
     updateVisitorPackage = (data) => {
+        let orderedPackage = this.reorderVisitorPackage(this.state.visitorPackage.concat(data))
         setTimeout(() => {
             this.setState({
-                visitorPackage: this.state.visitorPackage.concat(data),
+                visitorPackage: orderedPackage,
                 lastFetchedVisitors: data
             })
         }, 750)


### PR DESCRIPTION
Include a feature where signed in visitors who are currently sign in on a past date are automatically signed out. This is needed in order for Infinite Scroll and visitors signed out to be accurate.

- created put route: `api/signOutVisitors` that expects and requires `{"Options": "all-previous"}`. This is in anticipation the route will get used slightly differently in story 6.
- Updated DIC with controller and factory
- created `SignOutVisitorsController`
- created `SignOutVisitorsControllerFactory`
- updated `VisitorModel` with `signOutAllVisitorsUpToToday()` for updating db on re-render of admin page load
- created unit tests for both controller and factory
- updated documentation for new route
- FE - added the route to admin page to call the update when mounted
- included `->add('Authenticate')` to the route
- included logic to ensure correct data returned and organised by `DateOfVisit` first, then by `TimeOfSignOut` in `VisitorsSignedOutTable`
- fixed bug where infinite scroll is duplicating rows at the end
- fixed bug where .table-border bootstrap class was duplicating borders on `visitorsSignedOutTable`