### PR TITLE
S6 t1 sign all visitors out be

### DIFF
--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -37,6 +37,7 @@ class SignOutVisitorsController
         $option = $requestData['Option'];
         $now = new DateTime('Europe/London');
         $timeOfSignOut = $now->format('H:i:s');
+        $optionStatus = false;
 
         $apiResponse = [
             'Success' => false,
@@ -45,9 +46,13 @@ class SignOutVisitorsController
         ];
         $statusCode = 500;
 
-        if (!(isset($option)) || $option !== 'all-previous' || $option !== 'all-current') {
+        if ($option === 'all-previous' || $option === 'all-current') {
+            $optionStatus = true;
+        }
+
+        if (!(isset($option)) || $optionStatus === false) {
             $statusCode = 400;
-            $apiResponse['Message'] = 'Key must be \'Option\', must either be set and set to \'all-previous\' or \'all-current\'';
+            $apiResponse['Message'] = 'Key must be \'Option\'. Value must be either \'all-previous\' or \'all-current\'';
             return $response->withJson($apiResponse, $statusCode);
         }
 

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -45,14 +45,24 @@ class SignOutVisitorsController
         ];
         $statusCode = 500;
 
-        if (!(isset($option)) || $option !== 'all-previous') {
+        if (!(isset($option)) || $option !== 'all-previous' || $option !== 'all-current') {
             $statusCode = 400;
-            $apiResponse['Message'] = 'Key must be \'Option\', must be set and set to \'all-previous\'';
+            $apiResponse['Message'] = 'Key must be \'Option\', must either be set and set to \'all-previous\' or \'all-current\'';
             return $response->withJson($apiResponse, $statusCode);
         }
 
         if ($option === 'all-previous') {
             $updatedVisitors = $this->visitorModel->signOutAllVisitorsUpToToday($timeOfSignOut);
+            if ($updatedVisitors === true) {
+                $statusCode = 200;
+                $apiResponse['Success'] = true;
+                $apiResponse['Message'] = 'Successfully updated visitors';
+                return $response->withJson($apiResponse, $statusCode);
+            }
+        }
+
+        if ($option === 'all-current') {
+            $updatedVisitors = $this->visitorModel->signOutAllVisitors($timeOfSignOut);
             if ($updatedVisitors === true) {
                 $statusCode = 200;
                 $apiResponse['Success'] = true;

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -67,7 +67,7 @@ class SignOutVisitorsController
         }
 
         if ($option === 'all-current') {
-            $updatedVisitors = $this->visitorModel->signOutAllVisitors($timeOfSignOut);
+            $updatedVisitors = $this->visitorModel->signOutAllCurrentDayVisitors($timeOfSignOut);
             if ($updatedVisitors === true) {
                 $statusCode = 200;
                 $apiResponse['Success'] = true;

--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -174,4 +174,22 @@ class VisitorModel
         $query->bindParam(':timeOfSignOut', $timeOfSignOut);
         return $query->execute();
     }
+
+    /**
+     * signs out all visitors who are currently signed in today
+     *
+     * @param $timeOfSignOut
+     * @return bool
+     */
+    public function signOutAllVisitors($timeOfSignOut) : bool
+    {
+        $query = $this->db->prepare(
+            'UPDATE `visitors` 
+            SET `SignedIn` = 0, `TimeOfSignOut` = :timeOfSignOut
+            WHERE `SignedIn` = 1
+            AND `DateOfVisit` = CURDATE();'
+        );
+        $query->bindParam(':timeOfSignOut', $timeOfSignOut);
+        return $query->execute();
+    }
 }

--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -181,7 +181,7 @@ class VisitorModel
      * @param $timeOfSignOut
      * @return bool
      */
-    public function signOutAllVisitors($timeOfSignOut) : bool
+    public function signOutAllCurrentDayVisitors($timeOfSignOut) : bool
     {
         $query = $this->db->prepare(
             'UPDATE `visitors` 

--- a/app/src/Components/LandingPage/VisitorSignOutModal/VisitorSignOutModal.js
+++ b/app/src/Components/LandingPage/VisitorSignOutModal/VisitorSignOutModal.js
@@ -183,12 +183,12 @@ class VisitorSignOutModal extends React.Component
                 <div className="col-12 visitorsTable">
                     <table className="table table-bordered table-hover">
                         <thead>
-                        <tr>
-                            {this.generateHeader()}
-                        </tr>
+                            <tr>
+                                {this.generateHeader()}
+                            </tr>
                         </thead>
                         <tbody>
-                        {this.generateRows()}
+                            {this.generateRows()}
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
Add ability in BE to sign out all visitors currently signed in _today_

Task actions:
- updated `VisitorModel` with `signOutAllVisitors($timeOfSignOut)` method
- updated `SignOutVisitorsController` to handle `{ "Option": "all-current" }` which will call new method to sign out all visitors signed in in on current day

Integration tested successful with postman. Successfully handling bad requests.

To test via postman, you must first grab an authorised token and place this in the authorisation header tab as a bearer token:
- POST req: `localhost:8080/adminLogin`
- Send the following passcode JSON in the body: `{ "Passcode": 8974 }`

Then, do a PUT req to `localhost:8080/api/signOutVisitors`  with the bearer token in the authorisation header to sign out all signed in visitors on the current day.