### PR TITLE
S6 t2 sign all current day visitors out fe

### DIFF
--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -46,7 +46,7 @@ class VisitorModel
             'SELECT `id`, `Name`, `Company`, `DateOfVisit`, `TimeOfSignIn`, `TimeOfSignOut`
             FROM `visitors`
             WHERE `SignedIn` = 0
-            ORDER BY `DateOfVisit` DESC, `TimeOfSignOut` DESC;'
+            ORDER BY `id` DESC;'
         );
         $query->execute();
         return $query->fetchAll();

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -159,8 +159,6 @@ class VisitorsTableSignedOut extends React.Component {
 
         let fetchedNextBatch = await this.fetchVisitors(count, start)
         this.updateVisitorPackage(fetchedNextBatch)
-        console.log(this.state.visitorPackage)
-        console.log(start)
     }
 
     updateVisitorPackage = (data) => {

--- a/app/src/Components/LandingPage/AdminBtn/AdminBtn.css
+++ b/app/src/Components/LandingPage/AdminBtn/AdminBtn.css
@@ -4,7 +4,7 @@
     right: 50px;
     background-color: #F27424;
     color: #FFFFFF;
-    padding: 3px 25px;
+    padding: 2px 25px;
     font-weight: 700;
     font-size: 25px;
     border-radius: 5px;

--- a/app/src/Components/LandingPage/AdminBtn/AdminBtn.css
+++ b/app/src/Components/LandingPage/AdminBtn/AdminBtn.css
@@ -1,10 +1,10 @@
 .adminBtn {
     position: absolute;
-    bottom: 5%;
-    right: 5%;
+    bottom: 46px;
+    right: 50px;
     background-color: #F27424;
     color: #FFFFFF;
-    width: 150px;
+    padding: 3px 25px;
     font-weight: 700;
     font-size: 25px;
     border-radius: 5px;

--- a/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
+++ b/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
@@ -14,7 +14,6 @@ class AdminBtn extends React.Component {
                 this.setState({adminBtnClass: 'hidden'})
             }
         }
-
     }
 
     handleClick = () => {

--- a/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
+++ b/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
@@ -14,10 +14,15 @@ class AdminBtn extends React.Component {
                 this.setState({adminBtnClass: 'hidden'})
             }
         }
+
     }
 
     handleClick = () => {
         this.props.updateModalVisible();
+
+        if (!this.props.adminBtnActiveState) {
+            this.props.toggleAdminBtnState();
+        }
 
         if (this.props.signOutModalVisible) {
             this.props.updateSignOutModalVisible();

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -59,9 +59,15 @@ class AdminModal extends React.Component {
             if (this.props.adminBtnActiveState) {
                 window.location.replace(localStorage.getItem('appUrl') + 'AdminPage');
                 this.props.toggleAdminBtnState();
-            } else {
-                console.log('enter pressed but not action assigned')
+            } else if (this.props.signAllOutBtnActiveState) {
+                this.props.toggleSignAllOutBtnState();
+                let signAllOutResponse = await this.signAllOut();
+
+                if (signAllOutResponse.Success) {
+                    console.log('successfully signed folks out')
+                }
             }
+
         }
 
     };
@@ -77,6 +83,21 @@ class AdminModal extends React.Component {
         });
         return response.json();
     };
+
+    signAllOut = async () => {
+        const url = localStorage.getItem('apiUrl') + 'api/signOutVisitors';
+        const bodyData = JSON.stringify({ "Option" : "all-current" })
+        const response = await fetch(url, {
+            method: 'PUT',
+            body: bodyData,
+            headers: {
+                "Content-Type" : "application/json",
+                "Authorization" : "Bearer " + this.state.bearerToken
+            }
+        })
+
+        return await response.json();
+    }
 
     updateResponse = (newResponse) => {
         setTimeout(()=> {

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -131,7 +131,7 @@ class AdminModal extends React.Component {
                                     <span>0</span>
                             </button>
                             <button className="logInBtn btnHoverEffectGreen" onClick={this.handleLogin}>
-                                    <span>Log In</span>
+                                    <span>Enter</span>
                             </button>
                         </div>
                     </div>

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -51,7 +51,7 @@ class AdminModal extends React.Component {
             dataToSend
         );
 
-        if(passcodeResponse.success === false) {
+        if (passcodeResponse.success === false) {
             this.updateResponse(passcodeResponse.message);
         } else if (passcodeResponse.success === true) {
             this.updateToken(passcodeResponse.token);
@@ -60,17 +60,25 @@ class AdminModal extends React.Component {
                 window.location.replace(localStorage.getItem('appUrl') + 'AdminPage');
                 this.props.toggleAdminBtnState();
             } else if (this.props.signAllOutBtnActiveState) {
-                this.props.toggleSignAllOutBtnState();
-                let signAllOutResponse = await this.signAllOut();
-
-                if (signAllOutResponse.Success) {
-                    console.log('successfully signed folks out')
-                }
+                this.handleSignAllOutBtnClick()
             }
 
         }
 
     };
+
+    handleSignAllOutBtnClick = async () => {
+        this.props.toggleSignAllOutBtnState();
+        let signAllOutResponse = await this.signAllOut();
+
+        if (signAllOutResponse.Success) {
+            this.props.updateModalVisible()
+            if (!this.props.signAllOutSuccessTickState) {
+                this.props.toggleLandingPageSuccessTickState();
+            }
+        }
+        
+    }
 
     postPasscodeToDb = async (url, requestMethod, dataToSend) => {
         let requestData = JSON.stringify(dataToSend);

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -77,7 +77,7 @@ class AdminModal extends React.Component {
                 this.props.toggleLandingPageSuccessTickState();
             }
         }
-        
+
     }
 
     postPasscodeToDb = async (url, requestMethod, dataToSend) => {

--- a/app/src/Components/LandingPage/AdminModal/AdminModal.js
+++ b/app/src/Components/LandingPage/AdminModal/AdminModal.js
@@ -26,7 +26,7 @@ class AdminModal extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (prevProps.modalVisible !== this.props.modalVisible) {
-            if(this.props.modalVisible) {
+            if (this.props.modalVisible) {
                 this.setState({modalClass: 'visible'})
             } else {
                 this.setState({modalClass: 'hidden'})
@@ -35,17 +35,35 @@ class AdminModal extends React.Component {
     }
 
     captureInput = (e, keyPressed, passcodeUpdate) => {
-            let passcodeValue = {};
-                passcodeValue['passcode'] = passcodeUpdate + keyPressed;
+        let passcodeValue = {};
+            passcodeValue['passcode'] = passcodeUpdate + keyPressed;
         this.setState(passcodeValue)
     };
 
-    handleLogin = async (e)=>{
+    handleEnter = async () => {
         let dataToSend = {
             'Passcode': this.state.passcode
         };
         this.setState({passcode: ''});
-        await this.postPasscodeToDb(localStorage.getItem('apiUrl') + 'adminLogin', 'POST', dataToSend);
+        let passcodeResponse = await this.postPasscodeToDb(
+            localStorage.getItem('apiUrl') + 'adminLogin',
+            'POST',
+            dataToSend
+        );
+
+        if(passcodeResponse.success === false) {
+            this.updateResponse(passcodeResponse.message);
+        } else if (passcodeResponse.success === true) {
+            this.updateToken(passcodeResponse.token);
+
+            if (this.props.adminBtnActiveState) {
+                window.location.replace(localStorage.getItem('appUrl') + 'AdminPage');
+                this.props.toggleAdminBtnState();
+            } else {
+                console.log('enter pressed but not action assigned')
+            }
+        }
+
     };
 
     postPasscodeToDb = async (url, requestMethod, dataToSend) => {
@@ -57,13 +75,7 @@ class AdminModal extends React.Component {
                 "Content-Type" : "application/json"
             }
         });
-        let responseData = await response.json();
-        if(responseData.success === false) {
-            this.updateResponse(responseData.message);
-        } else if(responseData.success === true) {
-            this.updateToken(responseData.token);
-            window.location.replace(localStorage.getItem('appUrl') + 'AdminPage');
-        }
+        return response.json();
     };
 
     updateResponse = (newResponse) => {
@@ -130,7 +142,7 @@ class AdminModal extends React.Component {
                                     onClick={(e) => this.captureInput(e,'0', this.state.passcode)}>
                                     <span>0</span>
                             </button>
-                            <button className="logInBtn btnHoverEffectGreen" onClick={this.handleLogin}>
+                            <button className="logInBtn btnHoverEffectGreen" onClick={this.handleEnter}>
                                     <span>Enter</span>
                             </button>
                         </div>

--- a/app/src/Components/LandingPage/LandingPage.js
+++ b/app/src/Components/LandingPage/LandingPage.js
@@ -14,7 +14,8 @@ class LandingPage extends React.Component {
         signOutModalVisible: false,
         dataForSignOutModal: {},
         adminBtnActive: false,
-        signAllOutBtnActive: false
+        signAllOutBtnActive: false,
+        successTickActive: false
     };
 
     toggleAdminBtnState = () => {
@@ -23,6 +24,10 @@ class LandingPage extends React.Component {
 
     toggleSignAllOutBtnState = () => {
         this.setState({signAllOutBtnActive: !this.state.signAllOutBtnActive})
+    }
+
+    toggleSuccessTickState = () => {
+        this.setState({successTickActive: !this.state.successTickActive})
     }
 
     updateModalVisible = () => {
@@ -53,6 +58,8 @@ class LandingPage extends React.Component {
                 <MainContainer
                     updateSignOutModalVisible={this.updateSignOutModalVisible}
                     getSignOutData={this.getSignOutData}
+                    signAllOutSuccessTickState={this.state.successTickActive}
+                    toggleLandingPageSuccessTickState={this.toggleSuccessTickState}
                 />
                 <BackgroundOverlay
                     modalVisible={this.state.modalVisible}
@@ -65,6 +72,8 @@ class LandingPage extends React.Component {
                     toggleAdminBtnState={this.toggleAdminBtnState}
                     signAllOutBtnActiveState={this.state.signAllOutBtnActive}
                     toggleSignAllOutBtnState={this.toggleSignAllOutBtnState}
+                    signAllOutSuccessTickState={this.state.successTickActive}
+                    toggleLandingPageSuccessTickState={this.toggleSuccessTickState}
                 />
                 <VisitorSignOutModal
                     signOutModalVisible={this.state.signOutModalVisible}

--- a/app/src/Components/LandingPage/LandingPage.js
+++ b/app/src/Components/LandingPage/LandingPage.js
@@ -12,8 +12,13 @@ class LandingPage extends React.Component {
         modalVisible: false,
         adminBtnVisible: true,
         signOutModalVisible: false,
-        dataForSignOutModal: {}
+        dataForSignOutModal: {},
+        adminBtnActive: false
     };
+
+    toggleAdminBtnState = () => {
+        this.setState({adminBtnActive: !this.state.adminBtnActive})
+    }
 
     updateModalVisible = () => {
         if(!this.state.modalVisible) {
@@ -51,6 +56,8 @@ class LandingPage extends React.Component {
                 <AdminModal
                     modalVisible={this.state.modalVisible}
                     updateModalVisible={this.updateModalVisible}
+                    adminBtnActiveState={this.state.adminBtnActive}
+                    toggleAdminBtnState={this.toggleAdminBtnState}
                 />
                 <VisitorSignOutModal
                     signOutModalVisible={this.state.signOutModalVisible}
@@ -62,6 +69,8 @@ class LandingPage extends React.Component {
                     updateModalVisible={this.updateModalVisible}
                     signOutModalVisible={this.state.signOutModalVisible}
                     updateSignOutModalVisible={this.updateSignOutModalVisible}
+                    adminBtnActiveState={this.state.adminBtnActive}
+                    toggleAdminBtnState={this.toggleAdminBtnState}
                 />
                 <SignAllOutBtn
                     adminBtnVisible={this.state.adminBtnVisible}

--- a/app/src/Components/LandingPage/LandingPage.js
+++ b/app/src/Components/LandingPage/LandingPage.js
@@ -5,6 +5,7 @@ import AdminBtn from "./AdminBtn/AdminBtn";
 import AdminModal from "./AdminModal/AdminModal";
 import VisitorSignOutModal from "./VisitorSignOutModal/VisitorSignOutModal";
 import BackgroundOverlay from "../BackgroundOverlay/BackgroundOverlay";
+import SignAllOutBtn from "./SignAllOutBtn/SignAllOutBtn";
 
 class LandingPage extends React.Component {
     state = {
@@ -61,6 +62,9 @@ class LandingPage extends React.Component {
                     updateModalVisible={this.updateModalVisible}
                     signOutModalVisible={this.state.signOutModalVisible}
                     updateSignOutModalVisible={this.updateSignOutModalVisible}
+                />
+                <SignAllOutBtn
+                    adminBtnVisible={this.state.adminBtnVisible}
                 />
             </div>
         )

--- a/app/src/Components/LandingPage/LandingPage.js
+++ b/app/src/Components/LandingPage/LandingPage.js
@@ -65,6 +65,7 @@ class LandingPage extends React.Component {
                 />
                 <SignAllOutBtn
                     adminBtnVisible={this.state.adminBtnVisible}
+                    updateModalVisible={this.updateModalVisible}
                 />
             </div>
         )

--- a/app/src/Components/LandingPage/LandingPage.js
+++ b/app/src/Components/LandingPage/LandingPage.js
@@ -13,11 +13,16 @@ class LandingPage extends React.Component {
         adminBtnVisible: true,
         signOutModalVisible: false,
         dataForSignOutModal: {},
-        adminBtnActive: false
+        adminBtnActive: false,
+        signAllOutBtnActive: false
     };
 
     toggleAdminBtnState = () => {
         this.setState({adminBtnActive: !this.state.adminBtnActive})
+    }
+
+    toggleSignAllOutBtnState = () => {
+        this.setState({signAllOutBtnActive: !this.state.signAllOutBtnActive})
     }
 
     updateModalVisible = () => {
@@ -58,6 +63,8 @@ class LandingPage extends React.Component {
                     updateModalVisible={this.updateModalVisible}
                     adminBtnActiveState={this.state.adminBtnActive}
                     toggleAdminBtnState={this.toggleAdminBtnState}
+                    signAllOutBtnActiveState={this.state.signAllOutBtnActive}
+                    toggleSignAllOutBtnState={this.toggleSignAllOutBtnState}
                 />
                 <VisitorSignOutModal
                     signOutModalVisible={this.state.signOutModalVisible}
@@ -75,6 +82,8 @@ class LandingPage extends React.Component {
                 <SignAllOutBtn
                     adminBtnVisible={this.state.adminBtnVisible}
                     updateModalVisible={this.updateModalVisible}
+                    signAllOutBtnActiveState={this.state.signAllOutBtnActive}
+                    toggleSignAllOutBtnState={this.toggleSignAllOutBtnState}
                 />
             </div>
         )

--- a/app/src/Components/LandingPage/MainContainer/MainContainer.js
+++ b/app/src/Components/LandingPage/MainContainer/MainContainer.js
@@ -31,12 +31,29 @@ class MainContainer extends React.Component {
         this.setState({successTickVisible: 'hiddenOpacity'})
     };
 
+    animateSuccessTick = () => {
+        setTimeout( () => {
+            setTimeout(() => {
+                this.toggleSuccessTick()
+            },400);
+            this.setSuccessTickHidden()
+        }, 2000);
+        this.toggleSuccessTick()
+    }
+
     componentDidUpdate(prevProps, prevState) {
         if (prevState.successTick !== this.state.successTick) {
             if (this.state.successTick) {
                 this.setState({successTickVisible: 'visible'})
             } else {
                 this.setState({successTickVisible: 'hiddenOpacity'})
+            }
+        }
+
+        if (prevProps.signAllOutSuccessTickState !== this.props.signAllOutSuccessTickState) {
+            if (this.props.signAllOutSuccessTickState) {
+                this.animateSuccessTick()
+                this.props.toggleLandingPageSuccessTickState();
             }
         }
     }
@@ -65,6 +82,7 @@ class MainContainer extends React.Component {
                         getSignOutData={this.props.getSignOutData}
                         toggleSuccessTick={this.toggleSuccessTick}
                         setSuccessTickHidden={this.setSuccessTickHidden}
+                        animateSuccessTick={this.animateSuccessTick}
                     />
                     <div className="responseMessageFailed">
                         <MessageBox response={this.state.response}/>

--- a/app/src/Components/LandingPage/MainContainer/SignInForm/SigninForm.js
+++ b/app/src/Components/LandingPage/MainContainer/SignInForm/SigninForm.js
@@ -82,13 +82,7 @@ class SigninForm extends React.Component {
         let responseData = await response.json();
 
         if (responseData.Success) {
-            setTimeout( () => {
-                setTimeout(() => {
-                    this.props.toggleSuccessTick()
-                },400);
-                this.props.setSuccessTickHidden()
-            }, 2000);
-            this.props.toggleSuccessTick()
+            this.animateSuccessTick()
         }
 
         if (responseData.Data !== undefined) {
@@ -97,6 +91,16 @@ class SigninForm extends React.Component {
 
         return responseData;
     };
+
+    animateSuccessTick = () => {
+        setTimeout( () => {
+            setTimeout(() => {
+                this.props.toggleSuccessTick()
+            },400);
+            this.props.setSuccessTickHidden()
+        }, 2000);
+        this.props.toggleSuccessTick()
+    }
 
     render() {
         return (

--- a/app/src/Components/LandingPage/MainContainer/SignInForm/SigninForm.js
+++ b/app/src/Components/LandingPage/MainContainer/SignInForm/SigninForm.js
@@ -82,7 +82,7 @@ class SigninForm extends React.Component {
         let responseData = await response.json();
 
         if (responseData.Success) {
-            this.animateSuccessTick()
+            this.props.animateSuccessTick()
         }
 
         if (responseData.Data !== undefined) {
@@ -91,16 +91,6 @@ class SigninForm extends React.Component {
 
         return responseData;
     };
-
-    animateSuccessTick = () => {
-        setTimeout( () => {
-            setTimeout(() => {
-                this.props.toggleSuccessTick()
-            },400);
-            this.props.setSuccessTickHidden()
-        }, 2000);
-        this.props.toggleSuccessTick()
-    }
 
     render() {
         return (

--- a/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
+++ b/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
@@ -16,6 +16,13 @@ class SignAllOutBtn extends React.Component {
         }
     }
 
+    handleClick = () => {
+        this.props.updateModalVisible();
+
+        if (this.props.signOutModalVisible) {
+            this.props.updateSignOutModalVisible();
+        }
+    };
 
     render() {
         let signAllOutBtnVisibilityClass = 'signAllOutBtn btnHoverEffectOrange ' + this.state.signAllOutBtnVisibilityClass

--- a/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
+++ b/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
@@ -18,7 +18,6 @@ class SignAllOutBtn extends React.Component {
 
     handleClick = () => {
         this.props.updateModalVisible();
-        console.log(this.props.signAllOutBtnActiveState)
 
         if (!this.props.signAllOutBtnActiveState) {
             this.props.toggleSignAllOutBtnState();
@@ -27,6 +26,7 @@ class SignAllOutBtn extends React.Component {
         if (this.props.signOutModalVisible) {
             this.props.updateSignOutModalVisible();
         }
+
     };
 
     render() {

--- a/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
+++ b/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
@@ -9,9 +9,9 @@ class SignAllOutBtn extends React.Component {
     componentDidUpdate(prevProps) {
         if (prevProps.adminBtnVisible !== this.props.adminBtnVisible) {
             if(this.props.adminBtnVisible) {
-                this.setState({adminBtnClass: 'visible'})
+                this.setState({signAllOutBtnVisibilityClass: 'visible'})
             } else {
-                this.setState({adminBtnClass: 'hidden'})
+                this.setState({signAllOutBtnVisibilityClass: 'hidden'})
             }
         }
     }

--- a/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
+++ b/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
@@ -18,6 +18,11 @@ class SignAllOutBtn extends React.Component {
 
     handleClick = () => {
         this.props.updateModalVisible();
+        console.log(this.props.signAllOutBtnActiveState)
+
+        if (!this.props.signAllOutBtnActiveState) {
+            this.props.toggleSignAllOutBtnState();
+        }
 
         if (this.props.signOutModalVisible) {
             this.props.updateSignOutModalVisible();

--- a/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
+++ b/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
@@ -1,0 +1,28 @@
+import React from "react";
+import './signAllOutBtn.css';
+
+class SignAllOutBtn extends React.Component {
+    state = {
+        signAllOutBtnVisibilityClass: 'visible'
+    };
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.adminBtnVisible !== this.props.adminBtnVisible) {
+            if(this.props.adminBtnVisible) {
+                this.setState({adminBtnClass: 'visible'})
+            } else {
+                this.setState({adminBtnClass: 'hidden'})
+            }
+        }
+    }
+
+
+    render() {
+        let signAllOutBtnVisibilityClass = 'signAllOutBtn btnHoverEffectOrange ' + this.state.signAllOutBtnVisibilityClass
+        return (
+            <button className={signAllOutBtnVisibilityClass} onClick={this.handleClick}>Sign All Out</button>
+        )
+    }
+}
+
+export default SignAllOutBtn;

--- a/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
+++ b/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
@@ -1,0 +1,13 @@
+.signAllOutBtn {
+    position: absolute;
+    bottom: 46px;
+    right: 200px;
+    background-color: #F27424;
+    color: #FFFFFF;
+    padding: 3px 25px;
+    font-weight: 700;
+    font-size: 25px;
+    border-radius: 5px;
+    border: 1px solid #295074;
+    cursor: pointer;
+}

--- a/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
+++ b/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
@@ -4,7 +4,7 @@
     right: 200px;
     background-color: #F27424;
     color: #FFFFFF;
-    padding: 3px 25px;
+    padding: 2px 25px;
     font-weight: 700;
     font-size: 25px;
     border-radius: 5px;


### PR DESCRIPTION
Add functionality to FE to sign out all visitors currently signed in, in one go

Task actions:
- updated `LandingPage` component with a 'Sign All Out' button
- amended absolute positioning styling on admin button to fixed px instead of %
- ensured user needs to enter passcode in order to sign everyone out
- updated state in `LandingPage` with relevant toggle methods with, `adminBtnActive`, `signAllOutBtnActive`, `successTickActive` and passed both toggle methods and state through props where needed
- refactored `AdminModal` 'Log In' button to 'Enter' to be more generic and be able to handle an additional button that needs authentication
- refactored `handleLogIn` to `handleEnter` to first check passcode and do one or two actions based on which button is clicked
- created a `signAllOut()` method which calls PUT route, `api/signOutVisitors` with the body `{"Option" : "all-current"}` and updates all signed in visitors on current day to signed out
- created a `handleSignAllOutBtnClick()` method within `AdminModal` that calls `signAllOut()` method
- refactored successTick animation out of `SignInForm` to `MainContainer` and toggling through props
- updated API `VisitorModel`, `getAllSignedOutVisitors()` to return in order of `id` DESC to fix bug where `visitorsSignedOutTable` would miss off some of those signed out on the current day.
- Added success tick if signing all out successful: 
    > added to `componentDidUpdate` in `MainContainer` listening for a change on the `signAllOutSuccessTickState`. If passcode entered is correct and 'Sign All Out' button clicked, `signAllOutSuccessTickState` will change to true which will trigger the animation in `MainContainer`