### PR TITLE
Story 6 sign everyone out

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -178,8 +178,9 @@ To test, passcode is 8974.
 - Sets all visitors to signed out where signed in is true and date of visit is before current date
 - Logs time visitors signed out in the DB
 
-- Required and sends
-    - `{ "Option" : "all-previous" }` - Option with all-previous set
+- Required and sends through body either of the following:
+    - `{ "Option" : "all-previous" }` - Option with all-previous set. Signs out all visitors who's signed in status is set to 1 and date of visit is before current date.
+    - `{ "Option" : "all-current" }` - Option with all-previous set. Signs out all visitors who's signed in status is set to 1 irrespective of date of visit.
 
 - Returns:
     - if successful 

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -67,7 +67,7 @@ class SignOutVisitorsController
         }
 
         if ($option === 'all-current') {
-            $updatedVisitors = $this->visitorModel->signOutAllCurrentDayVisitors($timeOfSignOut);
+            $updatedVisitors = $this->visitorModel->signOutAllVisitors($timeOfSignOut);
             if ($updatedVisitors === true) {
                 $statusCode = 200;
                 $apiResponse['Success'] = true;

--- a/api/src/Classes/Controllers/SignOutVisitorsController.php
+++ b/api/src/Classes/Controllers/SignOutVisitorsController.php
@@ -37,6 +37,7 @@ class SignOutVisitorsController
         $option = $requestData['Option'];
         $now = new DateTime('Europe/London');
         $timeOfSignOut = $now->format('H:i:s');
+        $optionStatus = false;
 
         $apiResponse = [
             'Success' => false,
@@ -45,14 +46,28 @@ class SignOutVisitorsController
         ];
         $statusCode = 500;
 
-        if (!(isset($option)) || $option !== 'all-previous') {
+        if ($option === 'all-previous' || $option === 'all-current') {
+            $optionStatus = true;
+        }
+
+        if (!(isset($option)) || $optionStatus === false) {
             $statusCode = 400;
-            $apiResponse['Message'] = 'Key must be \'Option\', must be set and set to \'all-previous\'';
+            $apiResponse['Message'] = 'Key must be \'Option\'. Value must be either \'all-previous\' or \'all-current\'';
             return $response->withJson($apiResponse, $statusCode);
         }
 
         if ($option === 'all-previous') {
             $updatedVisitors = $this->visitorModel->signOutAllVisitorsUpToToday($timeOfSignOut);
+            if ($updatedVisitors === true) {
+                $statusCode = 200;
+                $apiResponse['Success'] = true;
+                $apiResponse['Message'] = 'Successfully updated visitors';
+                return $response->withJson($apiResponse, $statusCode);
+            }
+        }
+
+        if ($option === 'all-current') {
+            $updatedVisitors = $this->visitorModel->signOutAllCurrentDayVisitors($timeOfSignOut);
             if ($updatedVisitors === true) {
                 $statusCode = 200;
                 $apiResponse['Success'] = true;

--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -176,18 +176,17 @@ class VisitorModel
     }
 
     /**
-     * signs out all visitors who are currently signed in today
+     * signs out all visitors who are currently signed in
      *
      * @param $timeOfSignOut
      * @return bool
      */
-    public function signOutAllCurrentDayVisitors($timeOfSignOut) : bool
+    public function signOutAllVisitors($timeOfSignOut) : bool
     {
         $query = $this->db->prepare(
             'UPDATE `visitors` 
             SET `SignedIn` = 0, `TimeOfSignOut` = :timeOfSignOut
-            WHERE `SignedIn` = 1
-            AND `DateOfVisit` = CURDATE();'
+            WHERE `SignedIn` = 1'
         );
         $query->bindParam(':timeOfSignOut', $timeOfSignOut);
         return $query->execute();

--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -174,4 +174,22 @@ class VisitorModel
         $query->bindParam(':timeOfSignOut', $timeOfSignOut);
         return $query->execute();
     }
+
+    /**
+     * signs out all visitors who are currently signed in today
+     *
+     * @param $timeOfSignOut
+     * @return bool
+     */
+    public function signOutAllCurrentDayVisitors($timeOfSignOut) : bool
+    {
+        $query = $this->db->prepare(
+            'UPDATE `visitors` 
+            SET `SignedIn` = 0, `TimeOfSignOut` = :timeOfSignOut
+            WHERE `SignedIn` = 1
+            AND `DateOfVisit` = CURDATE();'
+        );
+        $query->bindParam(':timeOfSignOut', $timeOfSignOut);
+        return $query->execute();
+    }
 }

--- a/api/src/Classes/Models/VisitorModel.php
+++ b/api/src/Classes/Models/VisitorModel.php
@@ -46,7 +46,7 @@ class VisitorModel
             'SELECT `id`, `Name`, `Company`, `DateOfVisit`, `TimeOfSignIn`, `TimeOfSignOut`
             FROM `visitors`
             WHERE `SignedIn` = 0
-            ORDER BY `DateOfVisit` DESC, `TimeOfSignOut` DESC;'
+            ORDER BY `id` DESC;'
         );
         $query->execute();
         return $query->fetchAll();

--- a/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
+++ b/app/src/Components/AdminPage/AdminContainer/AdminContainer.js
@@ -6,6 +6,7 @@ import MessageBox from "../../LandingPage/MainContainer/MessageBox/MessageBox"
 import LogOutBtn from "../LogOutBtn/LogOutBtn";
 import TableSelector from "../TableSelector/TableSelector";
 import VisitorsTableSignedOut from "../VisitorsTableSignedOut/VisitorsTableSignedOut";
+import SignAllOutAdminPanelBtn from "../SignAllOutAdminPanelBtn/SignAllOutAdminPanelBtn";
 
 class AdminContainer extends React.Component {
     state = {
@@ -14,11 +15,16 @@ class AdminContainer extends React.Component {
         adminContainerVisible: 'hidden',
         signedInTableVisible: true,
         signedOutTableVisible: false,
-        visitorSignedOut: {}
+        visitorSignedOut: {},
+        updateSignedInTable: false
     };
 
     componentDidMount() {
         this.updateSignedOutDb()
+    }
+
+    toggleUpdateSignedInTable = () => {
+        this.setState({updateSignedInTable: !this.state.updateSignedInTable})
     }
 
     updateSignedOutDb = async () => {
@@ -77,6 +83,7 @@ class AdminContainer extends React.Component {
             <main>
                 <div className={adminContainerClass}>
                     <Logo/>
+                    <LogOutBtn/>
                     <div className="adminContainerButtons">
                         <TableSelector
                             signedInTableVisible={this.state.signedInTableVisible}
@@ -84,7 +91,10 @@ class AdminContainer extends React.Component {
                             viewSignedInVisitorTable={this.viewSignedInVisitorTable}
                             viewSignedOutVisitorTable={this.viewSignedOutVisitorTable}
                         />
-                        <LogOutBtn/>
+                        <SignAllOutAdminPanelBtn
+                            updateSignedInTableState={this.state.updateSignedInTable}
+                            toggleUpdateSignedInTable={this.toggleUpdateSignedInTable}
+                        />
                     </div>
                     <MessageBox
                         response={this.state.response}
@@ -95,11 +105,14 @@ class AdminContainer extends React.Component {
                         setAdminContainerVisible={this.setAdminContainerVisible}
                         signedInTableVisible={this.state.signedInTableVisible}
                         updateVisitorSignedOut={this.updateVisitorSignedOut}
+                        updateSignedInTableState={this.state.updateSignedInTable}
+                        toggleUpdateSignedInTable={this.toggleUpdateSignedInTable}
                     />
                     <VisitorsTableSignedOut
                         updateResponse={this.updateResponse}
                         signedOutTableVisible={this.state.signedOutTableVisible}
                         visitorSignedOut={this.state.visitorSignedOut}
+                        updateSignedInTableState={this.state.updateSignedInTable}
                     />
                 </div>
             </main>

--- a/app/src/Components/AdminPage/LogOutBtn/logOutBtn.css
+++ b/app/src/Components/AdminPage/LogOutBtn/logOutBtn.css
@@ -1,4 +1,5 @@
 .logOutBtn {
+    margin: 0 40px 20px 0;
     float: right;
     background-color: #F27424;
     color: #FFFFFF;

--- a/app/src/Components/AdminPage/SignAllOutAdminPanelBtn/SignAllOutAdminPanelBtn.js
+++ b/app/src/Components/AdminPage/SignAllOutAdminPanelBtn/SignAllOutAdminPanelBtn.js
@@ -1,0 +1,46 @@
+import React from "react";
+import '../../LandingPage/SignAllOutBtn/signAllOutBtn.css'
+
+class SignAllOutAdminPanelBtn extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            bearerToken: localStorage.getItem('bearerToken'),
+            apiUrl: localStorage.getItem('apiUrl')
+        }
+    }
+
+    handleClick = async () => {
+        let signAllOutResponse = await this.signAllOut();
+
+        if (signAllOutResponse.Success) {
+            if (!this.props.updateSignedInTableState) {
+                this.props.toggleUpdateSignedInTable();
+            }
+        }
+    };
+
+    signAllOut = async () => {
+        const url = localStorage.getItem('apiUrl') + 'api/signOutVisitors';
+        const bodyData = JSON.stringify({ "Option" : "all-current" })
+        const response = await fetch(url, {
+            method: 'PUT',
+            body: bodyData,
+            headers: {
+                "Content-Type" : "application/json",
+                "Authorization" : "Bearer " + this.state.bearerToken
+            }
+        })
+
+        return await response.json();
+    }
+
+    render() {
+        return (
+            <button className="signAllOutBtn btnHoverEffectOrange" onClick={this.handleClick}>Sign All Out</button>
+        )
+    }
+}
+
+export default SignAllOutAdminPanelBtn;

--- a/app/src/Components/AdminPage/VisitorsTableSignedIn/VisitorsTableSignedIn.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedIn/VisitorsTableSignedIn.js
@@ -28,6 +28,13 @@ class VisitorsTableSignedIn extends React.Component {
                 this.setState({signedInTableVisible: 'd-none'})
             }
         }
+
+        if (prevProps.updateSignedInTableState !== this.props.updateSignedInTableState) {
+            if (this.props.updateSignedInTableState) {
+                this.fetchVisitors()
+                this.props.toggleUpdateSignedInTable()
+            }
+        }
     }
 
     fetchVisitors = () => {

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -69,7 +69,8 @@ class VisitorsTableSignedOut extends React.Component {
             }
         }
 
-        if (prevProps.visitorSignedOut !== this.props.visitorSignedOut) {
+        if (prevProps.visitorSignedOut !== this.props.visitorSignedOut ||
+        prevProps.updateSignedInTableState !== this.props.updateSignedInTableState) {
             this.initialTableRenderData()
         }
     }

--- a/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
+++ b/app/src/Components/AdminPage/VisitorsTableSignedOut/VisitorsTableSignedOut.js
@@ -159,8 +159,6 @@ class VisitorsTableSignedOut extends React.Component {
 
         let fetchedNextBatch = await this.fetchVisitors(count, start)
         this.updateVisitorPackage(fetchedNextBatch)
-        console.log(this.state.visitorPackage)
-        console.log(start)
     }
 
     updateVisitorPackage = (data) => {

--- a/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
+++ b/app/src/Components/LandingPage/AdminBtn/AdminBtn.js
@@ -19,6 +19,10 @@ class AdminBtn extends React.Component {
     handleClick = () => {
         this.props.updateModalVisible();
 
+        if (!this.props.adminBtnActiveState) {
+            this.props.toggleAdminBtnState();
+        }
+
         if (this.props.signOutModalVisible) {
             this.props.updateSignOutModalVisible();
         }

--- a/app/src/Components/LandingPage/LandingPage.js
+++ b/app/src/Components/LandingPage/LandingPage.js
@@ -5,14 +5,30 @@ import AdminBtn from "./AdminBtn/AdminBtn";
 import AdminModal from "./AdminModal/AdminModal";
 import VisitorSignOutModal from "./VisitorSignOutModal/VisitorSignOutModal";
 import BackgroundOverlay from "../BackgroundOverlay/BackgroundOverlay";
+import SignAllOutBtn from "./SignAllOutBtn/SignAllOutBtn";
 
 class LandingPage extends React.Component {
     state = {
         modalVisible: false,
         adminBtnVisible: true,
         signOutModalVisible: false,
-        dataForSignOutModal: {}
+        dataForSignOutModal: {},
+        adminBtnActive: false,
+        signAllOutBtnActive: false,
+        successTickActive: false
     };
+
+    toggleAdminBtnState = () => {
+        this.setState({adminBtnActive: !this.state.adminBtnActive})
+    }
+
+    toggleSignAllOutBtnState = () => {
+        this.setState({signAllOutBtnActive: !this.state.signAllOutBtnActive})
+    }
+
+    toggleSuccessTickState = () => {
+        this.setState({successTickActive: !this.state.successTickActive})
+    }
 
     updateModalVisible = () => {
         if(!this.state.modalVisible) {
@@ -42,6 +58,8 @@ class LandingPage extends React.Component {
                 <MainContainer
                     updateSignOutModalVisible={this.updateSignOutModalVisible}
                     getSignOutData={this.getSignOutData}
+                    signAllOutSuccessTickState={this.state.successTickActive}
+                    toggleLandingPageSuccessTickState={this.toggleSuccessTickState}
                 />
                 <BackgroundOverlay
                     modalVisible={this.state.modalVisible}
@@ -50,6 +68,12 @@ class LandingPage extends React.Component {
                 <AdminModal
                     modalVisible={this.state.modalVisible}
                     updateModalVisible={this.updateModalVisible}
+                    adminBtnActiveState={this.state.adminBtnActive}
+                    toggleAdminBtnState={this.toggleAdminBtnState}
+                    signAllOutBtnActiveState={this.state.signAllOutBtnActive}
+                    toggleSignAllOutBtnState={this.toggleSignAllOutBtnState}
+                    signAllOutSuccessTickState={this.state.successTickActive}
+                    toggleLandingPageSuccessTickState={this.toggleSuccessTickState}
                 />
                 <VisitorSignOutModal
                     signOutModalVisible={this.state.signOutModalVisible}
@@ -61,6 +85,14 @@ class LandingPage extends React.Component {
                     updateModalVisible={this.updateModalVisible}
                     signOutModalVisible={this.state.signOutModalVisible}
                     updateSignOutModalVisible={this.updateSignOutModalVisible}
+                    adminBtnActiveState={this.state.adminBtnActive}
+                    toggleAdminBtnState={this.toggleAdminBtnState}
+                />
+                <SignAllOutBtn
+                    adminBtnVisible={this.state.adminBtnVisible}
+                    updateModalVisible={this.updateModalVisible}
+                    signAllOutBtnActiveState={this.state.signAllOutBtnActive}
+                    toggleSignAllOutBtnState={this.toggleSignAllOutBtnState}
                 />
             </div>
         )

--- a/app/src/Components/LandingPage/MainContainer/MainContainer.js
+++ b/app/src/Components/LandingPage/MainContainer/MainContainer.js
@@ -31,12 +31,29 @@ class MainContainer extends React.Component {
         this.setState({successTickVisible: 'hiddenOpacity'})
     };
 
+    animateSuccessTick = () => {
+        setTimeout( () => {
+            setTimeout(() => {
+                this.toggleSuccessTick()
+            },400);
+            this.setSuccessTickHidden()
+        }, 2000);
+        this.toggleSuccessTick()
+    }
+
     componentDidUpdate(prevProps, prevState) {
         if (prevState.successTick !== this.state.successTick) {
             if (this.state.successTick) {
                 this.setState({successTickVisible: 'visible'})
             } else {
                 this.setState({successTickVisible: 'hiddenOpacity'})
+            }
+        }
+
+        if (prevProps.signAllOutSuccessTickState !== this.props.signAllOutSuccessTickState) {
+            if (this.props.signAllOutSuccessTickState) {
+                this.animateSuccessTick()
+                this.props.toggleLandingPageSuccessTickState();
             }
         }
     }
@@ -65,6 +82,7 @@ class MainContainer extends React.Component {
                         getSignOutData={this.props.getSignOutData}
                         toggleSuccessTick={this.toggleSuccessTick}
                         setSuccessTickHidden={this.setSuccessTickHidden}
+                        animateSuccessTick={this.animateSuccessTick}
                     />
                     <div className="responseMessageFailed">
                         <MessageBox response={this.state.response}/>

--- a/app/src/Components/LandingPage/MainContainer/SignInForm/SigninForm.js
+++ b/app/src/Components/LandingPage/MainContainer/SignInForm/SigninForm.js
@@ -82,13 +82,7 @@ class SigninForm extends React.Component {
         let responseData = await response.json();
 
         if (responseData.Success) {
-            setTimeout( () => {
-                setTimeout(() => {
-                    this.props.toggleSuccessTick()
-                },400);
-                this.props.setSuccessTickHidden()
-            }, 2000);
-            this.props.toggleSuccessTick()
+            this.props.animateSuccessTick()
         }
 
         if (responseData.Data !== undefined) {

--- a/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
+++ b/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
@@ -1,0 +1,40 @@
+import React from "react";
+import './signAllOutBtn.css';
+
+class SignAllOutBtn extends React.Component {
+    state = {
+        signAllOutBtnVisibilityClass: 'visible'
+    };
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.adminBtnVisible !== this.props.adminBtnVisible) {
+            if(this.props.adminBtnVisible) {
+                this.setState({signAllOutBtnVisibilityClass: 'visible'})
+            } else {
+                this.setState({signAllOutBtnVisibilityClass: 'hidden'})
+            }
+        }
+    }
+
+    handleClick = () => {
+        this.props.updateModalVisible();
+
+        if (!this.props.signAllOutBtnActiveState) {
+            this.props.toggleSignAllOutBtnState();
+        }
+
+        if (this.props.signOutModalVisible) {
+            this.props.updateSignOutModalVisible();
+        }
+
+    };
+
+    render() {
+        let signAllOutBtnVisibilityClass = 'signAllOutBtn btnHoverEffectOrange ' + this.state.signAllOutBtnVisibilityClass
+        return (
+            <button className={signAllOutBtnVisibilityClass} onClick={this.handleClick}>Sign All Out</button>
+        )
+    }
+}
+
+export default SignAllOutBtn;

--- a/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
+++ b/app/src/Components/LandingPage/SignAllOutBtn/SignAllOutBtn.js
@@ -30,7 +30,8 @@ class SignAllOutBtn extends React.Component {
     };
 
     render() {
-        let signAllOutBtnVisibilityClass = 'signAllOutBtn btnHoverEffectOrange ' + this.state.signAllOutBtnVisibilityClass
+        let signAllOutBtnVisibilityClass = 'signAllOutBtn signAllOutBtnLandingPage btnHoverEffectOrange '
+            + this.state.signAllOutBtnVisibilityClass
         return (
             <button className={signAllOutBtnVisibilityClass} onClick={this.handleClick}>Sign All Out</button>
         )

--- a/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
+++ b/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
@@ -1,7 +1,4 @@
 .signAllOutBtn {
-    position: absolute;
-    bottom: 46px;
-    right: 200px;
     background-color: #F27424;
     color: #FFFFFF;
     padding: 2px 25px;
@@ -10,4 +7,10 @@
     border-radius: 5px;
     border: 1px solid #295074;
     cursor: pointer;
+}
+
+.signAllOutBtnLandingPage {
+    position: absolute;
+    bottom: 46px;
+    right: 200px;
 }

--- a/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
+++ b/app/src/Components/LandingPage/SignAllOutBtn/signAllOutBtn.css
@@ -1,7 +1,7 @@
-.adminBtn {
+.signAllOutBtn {
     position: absolute;
     bottom: 46px;
-    right: 50px;
+    right: 200px;
     background-color: #F27424;
     color: #FFFFFF;
     padding: 2px 25px;

--- a/app/src/Components/LandingPage/VisitorSignOutModal/VisitorSignOutModal.js
+++ b/app/src/Components/LandingPage/VisitorSignOutModal/VisitorSignOutModal.js
@@ -183,12 +183,12 @@ class VisitorSignOutModal extends React.Component
                 <div className="col-12 visitorsTable">
                     <table className="table table-bordered table-hover">
                         <thead>
-                        <tr>
-                            {this.generateHeader()}
-                        </tr>
+                            <tr>
+                                {this.generateHeader()}
+                            </tr>
                         </thead>
                         <tbody>
-                        {this.generateRows()}
+                            {this.generateRows()}
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
### **Story 6**
As a: Academy Employee I want: to be able to sign everyone out in one go So that: I can lock up the building quickly.

### **Requirements:**
-Secure sign all out system, restricted to admin users
-Must auto sign out everyone in building

The wireframe can be accessed here: https://docs.google.com/presentation/d/1fB-nv3A0bJiZv6gEzdCXq1golFK5DsNXYw2dYfYi5Es/edit#slide=id.g776c601bfd_1_4

### **Task 1 actions:**
Add ability in BE to sign out all visitors currently signed in _today_

- updated `VisitorModel` with `signOutAllVisitors($timeOfSignOut)` method
- updated `SignOutVisitorsController` to handle `{ "Option": "all-current" }` which will call new method to sign out all visitors signed in in on current day

Integration tested successful with postman. Successfully handling bad requests.

To test via postman, you must first grab an authorised token and place this in the authorisation header tab as a bearer token:
- POST req: `localhost:8080/adminLogin`
- Send the following passcode JSON in the body: `{ "Passcode": 8974 }`

Then, do a PUT req to `localhost:8080/api/signOutVisitors`  with the bearer token in the authorisation header and `{ "Option": "all-current" }` in the body to sign out all signed in visitors on the current day.


### **Task 2 actions:**
Add functionality to FE to sign out all visitors currently signed in, in one go

- updated `LandingPage` component with a 'Sign All Out' button
- amended absolute positioning styling on admin button to fixed px instead of % as adding another button next to it
- ensured user needs to enter passcode in order to sign everyone out
- updated state in `LandingPage` with relevant toggle methods; `adminBtnActive`, `signAllOutBtnActive`, `successTickActive` and passed both toggle methods and state through props where needed
- refactored `AdminModal` 'Log In' button to 'Enter' to be more generic and be able to handle an additional button that needs authentication
- refactored `handleLogIn` to `handleEnter` to first check passcode and do one or two actions based on which button is clicked
- created a `signAllOut()` method which calls PUT route, `api/signOutVisitors` with the body `{"Option" : "all-current"}` and updates all signed in visitors on current day to signed out
- created a `handleSignAllOutBtnClick()` method within `AdminModal` that calls `signAllOut()` method
- refactored successTick animation out of `SignInForm` to `MainContainer` and toggling through props
- updated API `VisitorModel`, `getAllSignedOutVisitors()` to return in order of `id` DESC to fix bug where `visitorsSignedOutTable` would miss off some of those signed out on the current day.
- Added success tick if signing all out successful: 
    _added to `componentDidUpdate` in `MainContainer` listening for a change on the `signAllOutSuccessTickState`. If passcode entered is correct and 'Sign All Out' button clicked, `signAllOutSuccessTickState` will change to true which will trigger the animation in `MainContainer`_

### **Task 3 actions:**
Made the 2 following amendments following code review:
1. Make sign all out button sign all signed in visitors flag change to signed out irrespective of date of sign in.
2. Add the sign all out button to admin container in case the user wanted to check who is signed in before signed everyone out. Saves them logging out then clicking the sign all out button on landing page

- updated `VisitorModel` with `signOutAllVisitors($timeOfSignOut)` method to sign all out irrespective of `DateOfVisit`
- updated `README.md` to explain what `{ "Option": "all-current" }` api route does
- moved `Log Out` button to own line to match wireframe
- created new component `Sign All Out` button and added to `Admin Container` 
- made sure signed in table updates when `Sign All Out` button clicked
- made sure visitors signed out table updates when `Sign All Out` button clicked
- amended styling of `Sign All Out` button by removing positioning styling and placing in its own class